### PR TITLE
Create wrapper for user name and avatar in the header

### DIFF
--- a/client/cypress/integration/header.e2e.js
+++ b/client/cypress/integration/header.e2e.js
@@ -69,46 +69,66 @@ describe('Header', () => {
       const openMenu = () => {
         cy.get(avatarSelector).click();
       };
-  
+
       it('should open user popover menu by click on avatar', () => {
         cy.get(avatarSelector).click();
         cy.get('[data-cy=user-menu]').should('be.visible');
       });
-  
+
       it('should open user popover menu by click on full name', () => {
         const fullName = getUserFullName();
-  
+
         cy.get('header').contains(fullName).click();
         cy.get('[data-cy=user-menu]').should('be.visible');
       });
-  
+
+      it('popover menu X position should be the same on avatar and full name clicks', () => {
+        const fullName = getUserFullName();
+
+        cy.get(avatarSelector).click();
+        cy.get('[data-cy=user-menu]')
+          .then(menu => {
+            const popMenuXCoordinateOnAvatarClick = menu[0].getBoundingClientRect().x;
+
+            cy.get('[data-cy=user-menu]').parent().parent().click();
+            cy.get('header').contains(fullName).click();
+
+            cy.get('[data-cy=user-menu]')
+              .then(menu => {
+                const popMenuXCoordinateOnFullNameClick = menu[0].getBoundingClientRect().x;
+
+                expect(popMenuXCoordinateOnAvatarClick).to.eq(popMenuXCoordinateOnFullNameClick);
+              });
+          });
+      });
+
       it('user menu should have `Profile` item that lead to Profile page', () => {
         openMenu();
-  
+
         cy.get('[data-cy=user-menu] li').contains('Profile').click();
-  
+
         cy.location().should(a => {
           const userData = getAuthorizedUser();
           expect(a.pathname).to.eq(`/profile/${userData.id}`);
         });
       });
-  
+
       it('user menu should have `My Posts` item that lead to user`s posts page', () => {
         openMenu();
-  
+
         cy.get('[data-cy=user-menu] li').contains('My posts').click();
-  
+
         cy.location().should(a => {
           const userData = getAuthorizedUser();
           expect(a.pathname).to.eq(`/profile/${userData.id}/posts`);
         });
       });
-  
+
       it('user menu should have `Log Out` item that does log out', () => {
         openMenu();
-  
+
         cy.get('[data-cy=user-menu] li').contains('Log Out').click();
-  
+
         cy.get('[data-cy=login-btn]').should('be.visible');
         cy.get('.header--for-authorised').should('not.be.visible')
           .then(testUserIsLoggedOut);

--- a/client/src/assets/styles/Header.css
+++ b/client/src/assets/styles/Header.css
@@ -11,10 +11,14 @@ header {
   z-index: 2;
 }
 .header--for-authorised {
-  cursor: pointer;
   display: flex;
   justify-content: flex-end;
   align-items: center;
+}
+.header__user-info-wrapper {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
 }
 .header__logo {
   height: 4rem;
@@ -25,7 +29,7 @@ header {
 .header__create-button {
   padding-right: 4rem;
 }
-.header__user-info {
+.header__user-info-name {
   padding-right: 1.6rem;
 }
 
@@ -48,7 +52,7 @@ header {
   header {
     padding: 0 1rem;
   }
-  .header__user-info {
+  .header__user-info-name {
     padding-right: 0.5rem;
   }
 }

--- a/client/src/components/containers/header/Header.jsx
+++ b/client/src/components/containers/header/Header.jsx
@@ -61,10 +61,12 @@ class Header extends React.Component {
               Create new post
             </Button>
           </div>
-          <div className={bemClasses('user-info')} onClick={this.handleOpenMenu}>
-            {`${this.props.user.FirstName} ${this.props.user.LastName}`}
+          <div className={bemClasses('user-info-wrapper')} onClick={this.handleOpenMenu}>
+            <div className={bemClasses('user-info-name')}>
+              {`${this.props.user.FirstName} ${this.props.user.LastName}`}
+            </div>
+            <Avatar alt="Username" src={this.props.user.PhotoUrl} data-cy="avatar" />
           </div>
-          <Avatar alt="Username" src={this.props.user.PhotoUrl} onClick={this.handleOpenMenu} data-cy="avatar" />
         </div>
         <Menu
           isOpen={this.state.isMenuOpen}


### PR DESCRIPTION
Before onClick event which opens popup user menu in header, was present
in both user name and avatar elements. This caused popup appearing in
different places because of different anchor elements.

Now onClick event is in wrapper element. And appears in the same place
irrespective of clicked element.

Some header styles  have also been changed, because earlier, cursor was always in
the shape of pointer not an arrow, even on blank spaces between add
create post button and user name element or between user name and user
avatar elements.

For now cursor changes to pointer only on header interface elements.